### PR TITLE
Add return type for `jsonSerialize` methods

### DIFF
--- a/src/Model/AddressAutocomplete/Location.php
+++ b/src/Model/AddressAutocomplete/Location.php
@@ -91,10 +91,7 @@ class Location implements LocationInterface, \JsonSerializable
         return $this->longitude;
     }
 
-    /**
-     * @return mixed
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'type' => $this->type,

--- a/src/Model/HolidayTimeSlot.php
+++ b/src/Model/HolidayTimeSlot.php
@@ -39,10 +39,7 @@ class HolidayTimeSlot implements HolidayTimeSlotInterface, \JsonSerializable
         return $this->endTime;
     }
 
-    /**
-     * @return mixed
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'startTime' => null !== $this->startTime ? $this->startTime->format('Y-m-d') : null,

--- a/src/Model/OpeningDay.php
+++ b/src/Model/OpeningDay.php
@@ -48,10 +48,7 @@ class OpeningDay implements OpeningDayInterface, \JsonSerializable
         $this->timeSlots[] = $timeSlot;
     }
 
-    /**
-     * @return mixed
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'dayCode' => $this->dayCode,

--- a/src/Model/OpeningDayTimeSlot.php
+++ b/src/Model/OpeningDayTimeSlot.php
@@ -39,10 +39,7 @@ class OpeningDayTimeSlot implements OpeningDayTimeSlotInterface, \JsonSerializab
         return $this->endTime;
     }
 
-    /**
-     * @return mixed
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'startTime' => $this->startTime,

--- a/src/Model/PickupPoint.php
+++ b/src/Model/PickupPoint.php
@@ -183,10 +183,7 @@ class PickupPoint implements PickupPointInterface, \JsonSerializable
         return $this->holidayItems;
     }
 
-    /**
-     * @return mixed
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'identifier' => $this->identifier,


### PR DESCRIPTION
Add return type on `jsonSerialize` methods to avoid warnings on front.