### PR TITLE
Add permission on partial routes and translations for Sylius plus RBAC plugin

### DIFF
--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -13,7 +13,7 @@ monsieurbiz_advanced_shipping_admin_shipping_calculator_configuration:
                 templates:
                     form: "@MonsieurBizSyliusAdvancedShippingPlugin/Admin/Calculator/_form.html.twig"
     type: sylius.resource
-    
+
 monsieurbiz_advanced_shipping_admin_shipping_calculator_configuration_create:
     path: /calculator-configurations/new/{calculator}
     methods: [GET, POST]
@@ -34,13 +34,6 @@ monsieurbiz_advanced_shipping_admin_shipping_calculator_configuration_create:
                 route:
                     parameters:
                         calculator: $calculator
-
-monsieurbiz_advanced_shipping_admin_get_shipping_calculators:
-    path: /shipping-calculators
-    methods: [GET]
-    defaults:
-        _controller: MonsieurBiz\SyliusAdvancedShippingPlugin\Controller\ShippingCalculatorController::getListAction
-        template: '@MonsieurBizSyliusAdvancedShippingPlugin/Admin/Calculator/list.html.twig'
 
 monsieurbiz_advanced_shipping_admin_shipping_address_provider_configuration:
     resource: |
@@ -79,13 +72,6 @@ monsieurbiz_advanced_shipping_admin_shipping_address_provider_configuration_crea
                     parameters:
                         provider: $provider
 
-monsieurbiz_advanced_shipping_admin_get_shipping_address_providers:
-    path: /shipping-adress-providers
-    methods: [GET]
-    defaults:
-        _controller: MonsieurBiz\SyliusAdvancedShippingPlugin\Controller\ShippingAddressProviderController::getProviderListAction
-        template: '@MonsieurBizSyliusAdvancedShippingPlugin/Admin/AddressProvider/list.html.twig'
-        
 monsieurbiz_advanced_shipping_admin_shipping_type:
     resource: |
         alias: monsieurbiz_advanced_shipping.shipping_type
@@ -138,9 +124,6 @@ monsieurbiz_advanced_shipping_admin_map_provider_configuration_create:
                     parameters:
                         provider: $provider
 
-monsieurbiz_advanced_shipping_admin_get_map_providers:
-    path: /map-providers
-    methods: [GET]
-    defaults:
-        _controller: MonsieurBiz\SyliusAdvancedShippingPlugin\Controller\MapProviderController::getProviderListAction
-        template: '@MonsieurBizSyliusAdvancedShippingPlugin/Admin/MapProvider/list.html.twig'
+monsieurbiz_advanced_shipping_admin_partial:
+    resource: "@MonsieurBizSyliusAdvancedShippingPlugin/Resources/config/routes/admin/partial.yaml"
+    prefix: /_partial

--- a/src/Resources/config/routes/admin/partial.yaml
+++ b/src/Resources/config/routes/admin/partial.yaml
@@ -4,6 +4,8 @@ monsieurbiz_advanced_shipping_admin_get_shipping_calculators:
     defaults:
         _controller: MonsieurBiz\SyliusAdvancedShippingPlugin\Controller\ShippingCalculatorController::getListAction
         template: '@MonsieurBizSyliusAdvancedShippingPlugin/Admin/Calculator/list.html.twig'
+        _sylius:
+            permission: true
 
 monsieurbiz_advanced_shipping_admin_get_shipping_address_providers:
     path: /shipping-adress-providers
@@ -11,6 +13,8 @@ monsieurbiz_advanced_shipping_admin_get_shipping_address_providers:
     defaults:
         _controller: MonsieurBiz\SyliusAdvancedShippingPlugin\Controller\ShippingAddressProviderController::getProviderListAction
         template: '@MonsieurBizSyliusAdvancedShippingPlugin/Admin/AddressProvider/list.html.twig'
+        _sylius:
+            permission: true
 
 monsieurbiz_advanced_shipping_admin_get_map_providers:
     path: /map-providers
@@ -18,3 +22,5 @@ monsieurbiz_advanced_shipping_admin_get_map_providers:
     defaults:
         _controller: MonsieurBiz\SyliusAdvancedShippingPlugin\Controller\MapProviderController::getProviderListAction
         template: '@MonsieurBizSyliusAdvancedShippingPlugin/Admin/MapProvider/list.html.twig'
+        _sylius:
+            permission: true

--- a/src/Resources/config/routes/admin/partial.yaml
+++ b/src/Resources/config/routes/admin/partial.yaml
@@ -1,0 +1,20 @@
+monsieurbiz_advanced_shipping_admin_get_shipping_calculators:
+    path: /shipping-calculators
+    methods: [GET]
+    defaults:
+        _controller: MonsieurBiz\SyliusAdvancedShippingPlugin\Controller\ShippingCalculatorController::getListAction
+        template: '@MonsieurBizSyliusAdvancedShippingPlugin/Admin/Calculator/list.html.twig'
+
+monsieurbiz_advanced_shipping_admin_get_shipping_address_providers:
+    path: /shipping-adress-providers
+    methods: [GET]
+    defaults:
+        _controller: MonsieurBiz\SyliusAdvancedShippingPlugin\Controller\ShippingAddressProviderController::getProviderListAction
+        template: '@MonsieurBizSyliusAdvancedShippingPlugin/Admin/AddressProvider/list.html.twig'
+
+monsieurbiz_advanced_shipping_admin_get_map_providers:
+    path: /map-providers
+    methods: [GET]
+    defaults:
+        _controller: MonsieurBiz\SyliusAdvancedShippingPlugin\Controller\MapProviderController::getProviderListAction
+        template: '@MonsieurBizSyliusAdvancedShippingPlugin/Admin/MapProvider/list.html.twig'

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -181,3 +181,10 @@ monsieurbiz_advanced_shipping:
             xoh: 'Relay Points compatible with D+1 delivery'
     colis_prive:
         search_placeholder: Please provide a postcode
+
+sylius_plus:
+    rbac:
+        parent:
+            shipping_address_provider_configurations: 'Shipping address provider configurations'
+            shipping_calculator_configurations: 'Calculator configurations'
+            shipping_types: 'Shipping Types'

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -42,7 +42,7 @@ monsieurbiz_advanced_shipping:
                 vous utilisez le mode inclusion, si le pays de l'adresse correspond à un pays de la règle, le tarif de 
                 la règle est appliqué. Si vous utilisez le mode exclusion, dans le cas où le pays de l'adresse ne 
                 correspond aucun pays de la règle, la règle est appliquée. Notez que seul le tarif de la 1ère règle 
-                valide rencontrée est appliqué. 
+                valide rencontrée est appliqué.
         customer_group_restriction:
             customer_group: Groupe client
         dpd_pickup_shiping_address_provider:
@@ -75,7 +75,7 @@ monsieurbiz_advanced_shipping:
             result_limit: 'Nombre de résultats'
             search_area: 'Zone de recherche (en km)'
             url: 'Url de l''API'
-        colis_prive_pickup_shipping_address_provider: 
+        colis_prive_pickup_shipping_address_provider:
             url: 'Url de l''API'
             account_id: Numéro de compte
             default_delay: 'Délais d''expédition par défaut'
@@ -97,7 +97,7 @@ monsieurbiz_advanced_shipping:
                 des codes postaux précis (80120,59160,60500) ou utiliser le caractère générique * (75* pour tout Paris ou 
                 2A*,2B*,20* pour la Corse). Si vous utilisez le mode inclusion, si un code postal correspond à un  masque, 
                 le tarif de la règle est appliqué. Si vous utilisez le mode exclusion, dans le cas où le code postal ne correspond à 
-                aucun masque, la règle est appliquée. Notez que seul le tarif de la 1ère règle valide rencontrée est appliqué. 
+                aucun masque, la règle est appliquée. Notez que seul le tarif de la 1ère règle valide rencontrée est appliqué.
         provider: Fournisseur
         shipping_address_provider: 'Fournisseur d''adresse d''expédition'
         table_rate_calculator_configuration:
@@ -178,6 +178,13 @@ monsieurbiz_advanced_shipping:
             med: 'Points Relais qui proposent la livraison en Point Relais® L'
             24r: 'Point Relais® XL + L + Lockers'
             24l: 'Points Relais qui proposent la livraison en Point Relais® XL '
-            xoh: 'Points Relais compatibles avec la livraison D+1 ' 
+            xoh: 'Points Relais compatibles avec la livraison D+1 '
     colis_prive:
         search_placeholder: Saisissez un code postal
+
+sylius_plus:
+    rbac:
+        parent:
+            shipping_address_provider_configurations: 'Configurations des fournisseurs d''adresses'
+            shipping_calculator_configurations: 'Configurations des calculateurs'
+            shipping_types: 'Types d''expédition'

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -177,8 +177,8 @@ monsieurbiz_advanced_shipping:
             rel: 'Points Relais qui proposent la collecte en Point Relais®'
             med: 'Points Relais qui proposent la livraison en Point Relais® L'
             24r: 'Point Relais® XL + L + Lockers'
-            24l: 'Points Relais qui proposent la livraison en Point Relais® XL '
-            xoh: 'Points Relais compatibles avec la livraison D+1 '
+            24l: 'Points Relais qui proposent la livraison en Point Relais® XL'
+            xoh: 'Points Relais compatibles avec la livraison D+1'
     colis_prive:
         search_placeholder: Saisissez un code postal
 


### PR DESCRIPTION
Add permission on routes so the RBAC of Sylius Plus can put be used for the routes of the plugin.

For Sylius Standard it's changing nothing.