### PR TITLE
Avoid error on `sylius:remove-expired-carts` when we have source order

### DIFF
--- a/dist/src/Migrations/Version20240329100612.php
+++ b/dist/src/Migrations/Version20240329100612.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Advanced Shipping plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240329100612 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_address DROP FOREIGN KEY FK_B97FF058CEBF5BEA');
+        $this->addSql('ALTER TABLE sylius_address ADD CONSTRAINT FK_B97FF058CEBF5BEA FOREIGN KEY (source_order_id) REFERENCES sylius_order (id) ON DELETE SET NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_address DROP FOREIGN KEY FK_B97FF058CEBF5BEA');
+        $this->addSql('ALTER TABLE sylius_address ADD CONSTRAINT FK_B97FF058CEBF5BEA FOREIGN KEY (source_order_id) REFERENCES sylius_order (id) ON UPDATE NO ACTION ON DELETE NO ACTION');
+    }
+}

--- a/src/Entity/AddressTemporaryAwareTrait.php
+++ b/src/Entity/AddressTemporaryAwareTrait.php
@@ -25,8 +25,7 @@ trait AddressTemporaryAwareTrait
 
     /**
      * @ORM\ManyToOne(targetEntity=OrderInterface::class, inversedBy="temporaryAddresses")
-     *
-     * @ORM\JoinColumn(name="source_order_id", referencedColumnName="id")
+     * @ORM\JoinColumn(name="source_order_id", referencedColumnName="id", onDelete="SET NULL")
      */
     private ?OrderInterface $sourceOrder = null;
 


### PR DESCRIPTION
**Before**

![image](https://github.com/monsieurbiz/SyliusAdvancedShippingPlugin/assets/465524/e54cf298-d8b8-4695-8eac-6c7a1417c03e)

**After**
![image](https://github.com/monsieurbiz/SyliusAdvancedShippingPlugin/assets/465524/a3438c17-b0c0-4190-b759-fb3c9f4ecdb7)
